### PR TITLE
Fix cachefile corruption when out of disk space.

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -241,11 +241,17 @@ class DataCollector:
 	# Save cacheable data
 	def saveCache(self, cachefile):
 		print 'Saving cache...'
-		f = open(cachefile, 'wb')
+		tempfile = cachefile + '.tmp'
+		f = open(tempfile, 'wb')
 		#pickle.dump(self.cache, f)
 		data = zlib.compress(pickle.dumps(self.cache))
 		f.write(data)
 		f.close()
+		try:
+			os.remove(cachefile)
+		except OSError:
+			pass
+		os.rename(tempfile, cachefile)
 
 class GitDataCollector(DataCollector):
 	def collect(self, dir):


### PR DESCRIPTION
Avoid corrupt cache by writing it to a temporary file first, and then
overwriting the original one. Should also fix other exceptional cases.

Thanks-to: Alexander Strasser eclipse7@gmx.net
