### PR TITLE
Fixed total LOC count for stats from multiple repositories

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -517,7 +517,7 @@ class GitDataCollector(DataCollector):
 					print 'Warning: failed to handle line "%s"' % line
 					(files, inserted, deleted) = (0, 0, 0)
 				#self.changes_by_date[stamp] = { 'files': files, 'ins': inserted, 'del': deleted }
-		self.total_lines = total_lines
+		self.total_lines += total_lines
 
 		# Per-author statistics
 


### PR DESCRIPTION
Total LOC in the General stats for multiple repositories shows the
total from the last project, not the aggregate from all projects.
