### PR TITLE
RHBZ#962168 - Add support for -h/--help options.

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -1348,10 +1348,21 @@ plot """
 </div>
 """)
 		
+def usage():
+	print """
+Usage: gitstats [options] <gitpath..> <outputpath>
+
+Options:
+-c key=value     Override configuration value
+
+Default config values:
+%s
+""" % conf
+
 
 class GitStats:
 	def run(self, args_orig):
-		optlist, args = getopt.getopt(args_orig, 'c:')
+		optlist, args = getopt.getopt(args_orig, 'hc:', ["help"])
 		for o,v in optlist:
 			if o == '-c':
 				key, value = v.split('=', 1)
@@ -1364,17 +1375,12 @@ class GitStats:
 					conf[key][kk] = vv
 				else:
 					conf[key] = value
+			elif o in ('-h', '--help'):
+				usage()
+				sys.exit()
 
 		if len(args) < 2:
-			print """
-Usage: gitstats [options] <gitpath..> <outputpath>
-
-Options:
--c key=value     Override configuration value
-
-Default config values:
-%s
-""" % conf
+			usage()
 			sys.exit(0)
 
 		outputpath = os.path.abspath(args[-1])


### PR DESCRIPTION
In response to user request added support for invoking with the -h or
--help argument to print usage information. Previously usage was only
printed if the user provided less than two arguments AND did not provide
any invalid arguments, as they were unhandled the commonly used -h and
--help arguments counted as invalid.

https://bugzilla.redhat.com/show_bug.cgi?id=962168
