### PR TITLE
Fix usage with multiple relative repository paths

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -1454,10 +1454,13 @@ class GitStats:
 		for gitpath in args[0:-1]:
 			print 'Git path: %s' % gitpath
 
+			prevdir = os.getcwd()
 			os.chdir(gitpath)
 
 			print 'Collecting data...'
 			data.collect(gitpath)
+
+			os.chdir(prevdir)
 
 		print 'Refining data...'
 		data.saveCache(cachefile)


### PR DESCRIPTION
### The problem

If you try to run gitstats with multiple relative repository paths, gitstats tries to find the second repository path inside the first one and fails because it cannot find it.

I've changed the code so that gitstats goes back to the previous path and retries to resolve the second repository path from their instead of trying it from inside the first one.
### Preparations

```
cd /tmp
git clone git@github.com:hoxu/gitstats.git gitstats
git clone git@github.com:hoxu/gitstats.git gitstats-copy
git clone git@github.com:hoxu/gitstats.git gitstats-another-copy
```
### Before my changes

```
jan@svadlupnir /tmp$ ./gitstats/gitstats gitstats gitstats-copy gitstats-another-copy dummy
[...]
[0.02922] >> git cat-file blob fd78f1007b22a2f7070b45b041e82ff3a6fce6c8 | wc -l
[0.01873] >> git cat-file blob 8dc44bc03bbcf1147e4b86dd3a3921f10a094784 | wc -l
[0.01322] >> git cat-file blob 89477324af7c51861534f193d262d9940bb99290 | wc -l
[0.01503] >> git cat-file blob d807cb05fd90fe7130e99b2b8bdc5d0fc6d6907b | wc -l
[0.01815] >> git cat-file blob c7f64e4754254711326793abba8989546da0317b | wc -l
[0.04474] >> git log --shortstat --first-parent -m --pretty=format:"%at %aN" HEAD
[0.04084] >> git log --shortstat --date-order --pretty=format:"%at %aN" HEAD
Git path: gitstats-copy
Traceback (most recent call last):
  File "./gitstats/gitstats", line 1483, in <module>
    g.run(sys.argv[1:])
  File "./gitstats/gitstats", line 1457, in run
    os.chdir(gitpath)
OSError: [Errno 2] No such file or directory: 'gitstats-copy'
```
### After my changes

```
jan@svadlupnir /tmp$ ./gitstats/gitstats gitstats gitstats-copy gitstats-another-copy dummy
[...]
[0.01300] >> gnuplot "/tmp/dummy/domains.plot"
[0.02229] >> gnuplot "/tmp/dummy/lines_of_code_by_author.plot"
[0.01098] >> gnuplot "/tmp/dummy/day_of_week.plot"
[0.01150] >> gnuplot "/tmp/dummy/hour_of_day.plot"
[0.01099] >> gnuplot "/tmp/dummy/lines_of_code.plot"
[0.02662] >> gnuplot "/tmp/dummy/commits_by_author.plot"
[0.01204] >> gnuplot "/tmp/dummy/month_of_year.plot"
[0.01123] >> gnuplot "/tmp/dummy/commits_by_year.plot"
[0.01092] >> gnuplot "/tmp/dummy/files_by_date.plot"
Execution time 1.20692 secs, 0.50970 secs (42.23 %) in external commands)
You may now run:

   sensible-browser '/tmp/dummy/index.html'
```
