### PR TITLE
Correct splitting of git-ls-tree output

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -482,7 +482,7 @@ class GitDataCollector(DataCollector):
 		for line in lines:
 			if len(line) == 0:
 				continue
-			parts = re.split('\s+', line, 5)
+			parts = re.split('\s+', line, 4)
 			if parts[0] == '160000' and parts[3] == '-':
 				# skip submodules
 				continue


### PR DESCRIPTION
Split limit 5 was off by one, which resulted in incorrect
processing of file paths with spaces embedded in them.
New split limit of 4 gets the required parts, because it
specifies the allowed number of splits, not elements:

mode type hash size name
    1    2    3    4
