### PR TITLE
use python2 enviroment

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2007-2014 Heikki Hokkanen <hoxu@users.sf.net> & others (see doc/AUTHOR)
 # GPLv2 / GPLv3
 import datetime


### PR DESCRIPTION
On systems like Arch Linux `python` defaults to `python3` preventing
gitstats to start. This fixes it.