### PR TITLE
Making it work on Ubutnu 16.04 on a repository with huge history

### DIFF
--- a/gitstats
+++ b/gitstats
@@ -57,13 +57,9 @@ def getpipeoutput(cmds, quiet = False):
 		print '>> ' + ' | '.join(cmds),
 		sys.stdout.flush()
 	p = subprocess.Popen(cmds[0], stdout = subprocess.PIPE, shell = True)
-	processes=[p]
 	for x in cmds[1:]:
 		p = subprocess.Popen(x, stdin = p.stdout, stdout = subprocess.PIPE, shell = True)
-		processes.append(p)
 	output = p.communicate()[0]
-	for p in processes:
-		p.wait()
 	end = time.time()
 	if not quiet:
 		if ON_LINUX and os.isatty(1):

--- a/gitstats
+++ b/gitstats
@@ -327,7 +327,7 @@ class GitDataCollector(DataCollector):
 
 		# Collect revision statistics
 		# Outputs "<stamp> <date> <time> <timezone> <author> '<' <mail> '>'"
-		lines = getpipeoutput(['git rev-list --pretty=format:"%%at %%ai %%aN <%%aE>" %s' % getlogrange('HEAD'), 'grep -v ^commit']).split('\n')
+		lines = getpipeoutput(['git rev-list --pretty=format:"%%at %%ai %%aN <%%aE>" %s' % getlogrange('HEAD'), 'grep -av ^commit']).split('\n')
 		for line in lines:
 			parts = line.split(' ', 4)
 			author = ''
@@ -434,7 +434,7 @@ class GitDataCollector(DataCollector):
 			self.commits_by_timezone[timezone] = self.commits_by_timezone.get(timezone, 0) + 1
 
 		# outputs "<stamp> <files>" for each revision
-		revlines = getpipeoutput(['git rev-list --pretty=format:"%%at %%T" %s' % getlogrange('HEAD'), 'grep -v ^commit']).strip().split('\n')
+		revlines = getpipeoutput(['git rev-list --pretty=format:"%%at %%T" %s' % getlogrange('HEAD'), 'grep -av ^commit']).strip().split('\n')
 		lines = []
 		revs_to_read = []
 		time_rev_count = []


### PR DESCRIPTION
1. we do not need to use process wait as process communicate waits until process termination and the last process in the pipeline do not finish until all processes before it in the pipeline terminate, plus process wait may deadlock on pipes with huge output, see notice at https://docs.python.org/2/library/subprocess.html
2. On Ubuntu 16.04 grep has started to give "Binary file (standard input) matches" notice into the pipe which breaks parsing.

This pull request fixes both issues making it working again on Ububtu 16.04 with our project.
