### PR TITLE
Add parameter end_date to pass a explicit time range to git

### DIFF
--- a/doc/gitstats.pod
+++ b/doc/gitstats.pod
@@ -63,7 +63,11 @@ Project name to show on the generated pages. Default is to use basename of the r
 
 =item start_date
 
-Specify a starting date to pass with --since to git.
+Specify a starting date to pass with --since to git. If end_date is used it will pass --after to git.
+
+=item end_date
+
+Specify a end date to pass with --before to git.
 
 =item style
 

--- a/gitstats
+++ b/gitstats
@@ -47,7 +47,8 @@ conf = {
 	'linear_linestats': 1,
 	'project_name': '',
 	'processes': 8,
-	'start_date': ''
+	'start_date': '',
+	'end_date': ''
 }
 
 def getpipeoutput(cmds, quiet = False):
@@ -74,8 +75,13 @@ def getpipeoutput(cmds, quiet = False):
 
 def getlogrange(defaultrange = 'HEAD', end_only = True):
 	commit_range = getcommitrange(defaultrange, end_only)
-	if len(conf['start_date']) > 0:
+	if len(conf['start_date']) > 0 and len(conf['end_date']) > 0:
+		return '--after="%s" --before="%s" "%s"' % (conf['start_date'],
+							    conf['end_date'],
+							    commit_range)
+	elif len(conf['start_date']) > 0:
 		return '--since="%s" "%s"' % (conf['start_date'], commit_range)
+
 	return commit_range
 
 def getcommitrange(defaultrange = 'HEAD', end_only = False):


### PR DESCRIPTION
It will pass --after/--before instead of --since if start_date and
end_date is used.